### PR TITLE
Fix the resulting value of Vuex module.state

### DIFF
--- a/src/module-definition-builder.ts
+++ b/src/module-definition-builder.ts
@@ -132,7 +132,7 @@ export class ModuleDefinitionBuilder<S, R> implements ModuleDefinition<S, R> {
 
     return {
       namespaced: false,
-      state: this._initialState,
+      state: this._initialState !== undefined ? () => this._initialState as S : undefined,
       mutations,
       actions,
       getters,


### PR DESCRIPTION
SSR apps require `state` to be a function in order to enable proper isolation on the server side.
